### PR TITLE
Remove `--ignore-scripts` from dockerfile `npm ci`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=secret,id=token \
     --mount=type=secret,id=username \
     NPM_AUTH_USERNAME=`cat /run/secrets/username` \
     NPM_AUTH_TOKEN=`cat /run/secrets/token` \
-    npm ci --production --no-optional --ignore-scripts
+    npm ci --production --no-optional
 
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,14 @@ FROM quay.io/ukhomeofficedigital/asl-base:v16
 
 RUN apk upgrade --no-cache
 
+USER 999
+
 COPY .npmrc /app/.npmrc
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 
-RUN --mount=type=secret,id=token \
-    --mount=type=secret,id=username \
+RUN --mount=type=secret,id=token,uid=999 \
+    --mount=type=secret,id=username,uid=999 \
     NPM_AUTH_USERNAME=`cat /run/secrets/username` \
     NPM_AUTH_TOKEN=`cat /run/secrets/token` \
     npm ci --production --no-optional
@@ -17,7 +19,5 @@ RUN --mount=type=secret,id=token \
 COPY . /app
 
 RUN rm /app/.npmrc
-
-USER 999
 
 CMD node index.js


### PR DESCRIPTION
The install script for `sharp` loads platform specific binaries, so if not allowed to run will cause the service to crash when started.