### PR TITLE
Set KMS encryption key id when creating objects

### DIFF
--- a/lib/routers/attachment.js
+++ b/lib/routers/attachment.js
@@ -27,7 +27,9 @@ module.exports = settings => {
           s3.upload({
             Bucket: settings.s3.bucket,
             Key: id,
-            Body
+            Body,
+            ServerSideEncryption: settings.s3.kms ? 'aws:kms' : undefined,
+            SSEKMSKeyId: settings.s3.kms
           }, (err, result) => {
             err ? reject(err) : resolve(file);
           });


### PR DESCRIPTION
S3 will reject objects without encryption settings defined.