### PR TITLE
integrate yarn workspace, gen package-lock json in pipeline before in…

### DIFF
--- a/.drone-1.0.yml
+++ b/.drone-1.0.yml
@@ -3,8 +3,12 @@ kind: pipeline
 name: default
 type: kubernetes
 steps:
+  - name: generate-package-lock
+    image: node:18
+    commands:
+      - npm ci --package-lock-only
   - name: install
-    image: node:16
+    image: node:18
     environment:
       ART_AUTH_TOKEN:
         from_secret: art_auth_token
@@ -13,7 +17,7 @@ steps:
     commands:
       - npm ci
   - name: test
-    image: node:16
+    image: node:18
     environment:
       ART_AUTH_TOKEN:
         from_secret: art_auth_token
@@ -22,7 +26,7 @@ steps:
     commands:
       - npm test
   - name: audit
-    image: node:16
+    image: node:18
     environment:
       ART_AUTH_TOKEN:
         from_secret: art_auth_token


### PR DESCRIPTION
It's been difficult to see how to manage yarn workspace AKA `aspel-workspace`. As workspace use hoisting features and ASPeL CI is not prepared for it. 
So a workaround is to create a package-lock.json before the CI run install cmd. 